### PR TITLE
Js/frontend/safe images

### DIFF
--- a/js/frontend/safe-images.js
+++ b/js/frontend/safe-images.js
@@ -1,0 +1,30 @@
+/**
+ * Sets up safe images on the webpage by assigning a fallback image 
+ * whenever an error occurs while loading the original image.
+ *
+ * @param {string} safeImagesClass - CSS class identifying the images to be processed.
+ * @param {string} fallbackImagePath - Path to the image used as a fallback in case of an error.
+ * @param {string} [altIfNotFound='resource not found'] - Alternative text assigned to the fallback image.
+ */
+function setupSafeImages(safeImagesClass, fallbackImagePath, altIfNotFound = 'resource not found') {
+
+    const elements = document.getElementsByClassName(safeImagesClass)
+
+    for (const element of elements) {
+
+        if (element.tagName.toLowerCase() !== 'img' || !element.hasAttribute('src')) continue
+
+        const setFallbackImage = () => {
+            element.setAttribute('src', fallbackImagePath)
+            element.setAttribute('alt', altIfNotFound)
+        }
+
+        element.addEventListener('error', setFallbackImage)
+
+        const checkImage = new Image()
+        checkImage.src = element.src
+        checkImage.onerror = setFallbackImage
+
+        element.setAttribute('draggable', 'false')
+    }
+}

--- a/js/frontend/safe-images.js
+++ b/js/frontend/safe-images.js
@@ -5,26 +5,31 @@
  * @param {string} safeImagesClass - CSS class identifying the images to be processed.
  * @param {string} fallbackImagePath - Path to the image used as a fallback in case of an error.
  * @param {string} [altIfNotFound='resource not found'] - Alternative text assigned to the fallback image.
+ * @throws {Error} If couldn't find the fallback image
  */
 function setupSafeImages(safeImagesClass, fallbackImagePath, altIfNotFound = 'resource not found') {
 
-    const elements = document.getElementsByClassName(safeImagesClass)
+    const fallbackValidator = new Image();
+    fallbackValidator.src = fallbackImagePath;
+    fallbackValidator.onerror = () => {
+        throw new Error(`Fallback image not found at: ${fallbackImagePath}`);
+    };
 
+    const elements = document.getElementsByClassName(safeImagesClass);
     for (const element of elements) {
-
-        if (element.tagName.toLowerCase() !== 'img' || !element.hasAttribute('src')) continue
+        if (element.tagName.toLowerCase() !== 'img' || !element.hasAttribute('src')) continue;
 
         const setFallbackImage = () => {
-            element.setAttribute('src', fallbackImagePath)
-            element.setAttribute('alt', altIfNotFound)
-        }
+            element.setAttribute('src', fallbackImagePath);
+            element.setAttribute('alt', altIfNotFound);
+        };
 
-        element.addEventListener('error', setFallbackImage)
+        element.addEventListener('error', setFallbackImage);
 
         const checkImage = new Image()
         checkImage.src = element.src
         checkImage.onerror = setFallbackImage
 
-        element.setAttribute('draggable', 'false')
+        element.setAttribute('draggable', 'false');
     }
 }


### PR DESCRIPTION
# Safe images
```js

setupSafeImages('safe-image', '/path/to/fallback', 'resource not found')
```

 Sets up safe images on the webpage by assigning a fallback image whenever an error occurs while loading the original image.
> [!CAUTION]
> Throws an error if it couldn't find the fallback image 
